### PR TITLE
victara: remove non-existant dhcpcd.conf inclusion

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -241,7 +241,6 @@ PRODUCT_PACKAGES += \
 
 # Wifi
 PRODUCT_PACKAGES += \
-    dhcpcd.conf \
     hostapd \
     hostapd_default.conf \
     hostapd.accept \


### PR DESCRIPTION
Change-Id: I7221f05d98ea7bfbdd3c935302fd7d68b99a59bb
